### PR TITLE
Add first child and last child flags to cache

### DIFF
--- a/ecs/src/tree.rs
+++ b/ecs/src/tree.rs
@@ -56,19 +56,19 @@ impl Tree {
         iterator.collect::<Vec<_>>()
     }
 
-    pub fn get_first_child(&self, entity: Entity) -> Option<Entity> {
+    pub fn get_first_child(&self, entity: &Entity) -> Option<&Entity> {
 
         if let Some(first_child) = self.first_child.get(entity.index()) {
-            return *first_child;
+            return first_child.as_ref();
         }
 
         None
     }
 
-    pub fn get_next_sibling(&self, entity: Entity) -> Option<Entity> {
+    pub fn get_next_sibling(&self, entity: &Entity) -> Option<&Entity> {
 
         if let Some(next_sibling) = self.next_sibling.get(entity.index()) {
-            return *next_sibling;
+            return next_sibling.as_ref();
         }
 
         None
@@ -110,14 +110,15 @@ impl<'a> Iterator for DownwardIterator<'a> {
 
 pub struct ChildIterator<'a> {
     pub tree: &'a Tree,
-    pub current_node: Option<Entity>,
+    pub current_node: Option<&'a Entity>,
 }
 
 impl<'a> Iterator for ChildIterator<'a> {
-    type Item = Entity;
-    fn next(&mut self) -> Option<Entity> {
+    type Item = &'a Entity;
+    fn next(&mut self) -> Option<Self::Item> {
         if let Some(entity) = self.current_node {
-            self.current_node = self.tree.next_sibling[entity.index()];
+            //self.current_node = self.tree.next_sibling[entity.index()].as_ref();
+            self.current_node = self.tree.get_next_sibling(entity);
             return Some(entity);
         }
 

--- a/examples/position_type_self_directed.rs
+++ b/examples/position_type_self_directed.rs
@@ -24,8 +24,9 @@ fn main() {
     world.set_position_type(child1, PositionType::SelfDirected);
 
     let child2 = world.add(Some(root));
-    world.set_width(child2, Units::Pixels(100.0));
-    world.set_height(child2, Units::Pixels(100.0));
+    world.set_width(child2, Units::Pixels(150.0));
+    world.set_height(child2, Units::Pixels(150.0));
+
 
     let child3 = world.add(Some(root));
     world.set_width(child3, Units::Pixels(100.0));

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -67,4 +67,9 @@ pub trait Cache {
     fn set_right(&mut self, node: &Self::Item, value: f32);
     fn set_top(&mut self, node: &Self::Item, value: f32);
     fn set_bottom(&mut self, node: &Self::Item, value: f32);
+
+    fn stack_first_child(&self, node: &Self::Item) -> bool;
+    fn set_stack_first_child(&mut self, node: &Self::Item, value: bool);
+    fn stack_last_child(&self, node: &Self::Item) -> bool;
+    fn set_stack_last_child(&mut self, node: &Self::Item, value: bool);
 }

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -4,13 +4,13 @@ use crate::node::Node;
 /// Describes a visual tree of nodes which can be layed out
 pub trait Hierarchy<'a> {
     /// A type respresenting a node in the visual tree
-    type Item: Node;
+    type Item: 'a + Node;
     /// A type respresenting an iterator that walks up the visual tree 
     type UpIter: Iterator<Item = Self::Item>;
     /// A type representing an iterator that walks down the visual tree
     type DownIter: Iterator<Item = Self::Item>;
     /// A type representing an iterator which iterates through the children of a specified node
-    type ChildIter: Iterator<Item = Self::Item>;
+    type ChildIter: Iterator<Item = &'a Self::Item>;
 
     /// Returns an iterator which walks up the hierarchy
     fn up_iter(&self) -> Self::UpIter;
@@ -22,7 +22,7 @@ pub trait Hierarchy<'a> {
     fn child_iter(&'a self, node: &Self::Item) -> Self::ChildIter;
 
     /// Get the parent node of the specified node
-    fn parent(&self, node: &Self::Item) -> Option<Self::Item>;
+    fn parent(&self, node: &Self::Item) -> Option<&Self::Item>;
 
     /// Returns true if the specified node is the first child of its parent
     fn is_first_child(&self, node: &Self::Item) -> bool;

--- a/src/node.rs
+++ b/src/node.rs
@@ -192,6 +192,6 @@ pub trait Node: Clone + std::fmt::Debug {
     }
 }
 
-impl<T: Node> Node for Option<T> {
+impl<'a, T: Node> Node for Option<&'a T> {
     type Data = <T as Node>::Data;
 }


### PR DESCRIPTION
Fix positioning of self-directed nodes. Fixes #1.
Also changes changes ChildIterator in ECS to return an iterator over references. 