### PR TITLE
Add content_width and content_height

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -142,6 +142,8 @@ pub fn layout<'a, C, H>(
             node.min_bottom(store).unwrap_or_default().value_or(parent_width, -std::f32::MAX);
         let max_bottom =
             node.max_bottom(store).unwrap_or_default().value_or(parent_width, std::f32::MAX);
+        let content_width = node.content_width(store).unwrap_or_default();
+        let content_height = node.content_height(store).unwrap_or_default();
 
         let width = node.width(store).unwrap_or(Units::Stretch(1.0));
         let height = node.height(store).unwrap_or(Units::Stretch(1.0));
@@ -155,7 +157,7 @@ pub fn layout<'a, C, H>(
                 LayoutType::Grid => cache.grid_row_max(node),
             },
         );
-        min_width = min_width.clamp(0.0, std::f32::MAX);
+        min_width = min_width.clamp(content_width, std::f32::MAX);
 
         let mut max_width =
             node.max_width(store).unwrap_or_default().value_or(parent_width, std::f32::MAX);
@@ -170,7 +172,7 @@ pub fn layout<'a, C, H>(
                 LayoutType::Grid => cache.grid_col_max(node),
             },
         );
-        min_height = min_height.clamp(0.0, std::f32::MAX);
+        min_height = min_height.clamp(content_height, std::f32::MAX);
 
         let mut max_height =
             node.max_height(store).unwrap_or_default().value_or(parent_height, std::f32::MAX);
@@ -508,8 +510,10 @@ pub fn layout<'a, C, H>(
 
                     let width = node.width(store).unwrap_or(Units::Stretch(1.0));
                     let height = node.height(store).unwrap_or(Units::Stretch(1.0));
+                    let content_width = node.content_width(store).unwrap_or(0.0);
+                    let content_height = node.content_height(store).unwrap_or(0.0);
 
-                    // This could be cached during up phase because it shouldn't change between up phase and down phase
+                    // TODO - This could be cached during up phase because it shouldn't change between up phase and down phase
                     let mut min_width = node.min_width(store).unwrap_or_default().value_or(
                         parent_width,
                         match layout_type {
@@ -518,7 +522,7 @@ pub fn layout<'a, C, H>(
                             LayoutType::Grid => cache.grid_row_max(node),
                         },
                     );
-                    min_width = min_width.clamp(0.0, std::f32::MAX);
+                    min_width = min_width.clamp(content_width, std::f32::MAX);
 
                     let mut max_width = node
                         .max_width(store)
@@ -535,7 +539,7 @@ pub fn layout<'a, C, H>(
                             LayoutType::Grid => cache.grid_col_max(node),
                         },
                     );
-                    min_height = min_height.clamp(0.0, std::f32::MAX);
+                    min_height = min_height.clamp(content_height, std::f32::MAX);
 
                     let mut max_height = node
                         .max_height(store)

--- a/src/node.rs
+++ b/src/node.rs
@@ -55,6 +55,16 @@ pub trait Node<'w>: Clone + Copy + std::fmt::Debug {
         Some(Units::Auto)
     }
 
+    /// Get the measured width of the node's content (not children) in pixels
+    fn content_width(&self, store: &'_ Self::Data) -> Option<f32> {
+        Some(0.0)
+    }
+
+    /// Get the measured height of the node's content (not children) in pixels
+    fn content_height(&self, store: &'_ Self::Data) -> Option<f32> {
+        Some(0.0)
+    }
+
     /// Get the desired space to the left of the node in units
     fn left(&self, store: &'_ Self::Data) -> Option<Units> {
         Some(Units::Auto)


### PR DESCRIPTION
For nodes which have content, it is inappropriate to put the measured size of that content into min_width and min_height, since the user may want to specify their own min_width and min_height. We cannot just take the max of the user-specified min_dim and the calculated content dimension any time before layout is in progress, since the user-specified min_width and min_height may not be in units of pixels. Therefore, this PR adds content_width and content_height properties which are additional lower-bound constraints on the specified dimension, combined with min_width and min_height during layout.

This should be a backwards-compatible change, since if the content_width and content_height Node trait methods are not implemented, they will default to returning zero.